### PR TITLE
fix: 🐛 format date as medium style, improve mobile padding

### DIFF
--- a/apps/web/app/components/media-overview-list.tsx
+++ b/apps/web/app/components/media-overview-list.tsx
@@ -13,7 +13,7 @@ export const MediaOverviewList = ({
   )[];
 }) => {
   return (
-    <div className="grid grid-cols-2 gap-8 md:grid-cols-4">
+    <div className="grid grid-cols-2 gap-2 md:grid-cols-4 lg:gap-8">
       {items.map((item) => {
         return (
           <div className="dsy-card" key={item.title}>

--- a/apps/web/app/components/movie-card.tsx
+++ b/apps/web/app/components/movie-card.tsx
@@ -1,5 +1,5 @@
 import { tmdbImageUrl } from "@popcorn.fyi/tmdb";
-import { formatDateAsYearOnly } from "@popcorn.fyi/utils";
+import { year } from "@popcorn.fyi/utils";
 import { Link } from "@tanstack/react-router";
 
 import { MediaRating } from "./media-rating";
@@ -30,9 +30,7 @@ export const MovieCard = ({ movie }: MovieCardProps) => {
           <MediaRating average={movie.vote_average} />
         </div>
         <h2 className="dsy-card-title">{movie.title}</h2>
-        {movie.release_date ? (
-          <p>{formatDateAsYearOnly(movie.release_date)}</p>
-        ) : null}
+        {movie.release_date ? <p>{year(movie.release_date)}</p> : "N/A"}
         <div className="dsy-card-actions justify-end">
           <Link
             className="dsy-btn dsy-btn-secondary dsy-btn-sm"

--- a/apps/web/app/components/movie-details.tsx
+++ b/apps/web/app/components/movie-details.tsx
@@ -19,7 +19,7 @@ interface MovieDetailsProps {
 
 export const MovieDetails = ({ movie }: MovieDetailsProps) => {
   return (
-    <div className="flex min-h-screen flex-col gap-4 p-8">
+    <div className="flex min-h-screen flex-col gap-4 md:p-4 lg:p-8">
       <div className="mx-auto hidden max-w-7xl md:block">
         {movie.backdrop_path ? (
           <img
@@ -34,7 +34,7 @@ export const MovieDetails = ({ movie }: MovieDetailsProps) => {
           {movie.poster_path ? (
             <img
               alt={movie.title}
-              className="max-w-xl rounded-lg shadow-2xl md:hidden lg:block"
+              className="w-full rounded-lg shadow-2xl md:hidden md:max-w-xl lg:block"
               src={tmdbImageUrl(movie.poster_path, "w300")}
             />
           ) : null}

--- a/apps/web/app/components/tv-show-card.tsx
+++ b/apps/web/app/components/tv-show-card.tsx
@@ -1,5 +1,5 @@
 import { tmdbImageUrl } from "@popcorn.fyi/tmdb";
-import { formatDateAsYearOnly } from "@popcorn.fyi/utils";
+import { year } from "@popcorn.fyi/utils";
 import { Link } from "@tanstack/react-router";
 
 import { MediaRating } from "./media-rating";
@@ -30,9 +30,7 @@ export const TVShowCard = ({ tvShow }: TVShowCardProps) => {
           <MediaRating average={tvShow.vote_average} />
         </div>
         <h2 className="dsy-card-title">{tvShow.name}</h2>
-        {tvShow.first_air_date ? (
-          <p>{formatDateAsYearOnly(tvShow.first_air_date)}</p>
-        ) : null}
+        {tvShow.first_air_date ? <p>{year(tvShow.first_air_date)}</p> : "N/A"}
         <div className="dsy-card-actions justify-end">
           <Link
             className="dsy-btn dsy-btn-secondary dsy-btn-sm"

--- a/apps/web/app/components/tv-show-details.tsx
+++ b/apps/web/app/components/tv-show-details.tsx
@@ -19,7 +19,7 @@ interface TVShowDetailsProps {
 
 export const TVShowDetails = ({ tvShow }: TVShowDetailsProps) => {
   return (
-    <div className="flex min-h-screen flex-col gap-4 p-8">
+    <div className="flex min-h-screen flex-col gap-4 md:p-4 lg:p-8">
       <div className="mx-auto hidden max-w-7xl md:block">
         {tvShow.backdrop_path ? (
           <img
@@ -34,7 +34,7 @@ export const TVShowDetails = ({ tvShow }: TVShowDetailsProps) => {
           {tvShow.poster_path ? (
             <img
               alt={tvShow.name}
-              className="max-w-xl rounded-lg shadow-2xl md:hidden lg:block"
+              className="w-full rounded-lg shadow-2xl md:hidden md:max-w-xl lg:block"
               src={tmdbImageUrl(tvShow.poster_path, "w300")}
             />
           ) : null}

--- a/apps/web/app/routes/_layout.movies.$id.index.tsx
+++ b/apps/web/app/routes/_layout.movies.$id.index.tsx
@@ -1,4 +1,4 @@
-import { formatDateAsLongMonth } from "@popcorn.fyi/utils";
+import { date } from "@popcorn.fyi/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
@@ -18,9 +18,7 @@ function RouteComponent() {
   const overview = [
     {
       title: "Release Date",
-      value: movie.release_date
-        ? formatDateAsLongMonth(movie.release_date)
-        : "N/A",
+      value: movie.release_date ? date(movie.release_date) : "N/A",
     },
     {
       title: "Status",

--- a/apps/web/app/routes/_layout.tv-shows.$id.index.tsx
+++ b/apps/web/app/routes/_layout.tv-shows.$id.index.tsx
@@ -1,4 +1,4 @@
-import { formatDateAsLongMonth } from "@popcorn.fyi/utils";
+import { date } from "@popcorn.fyi/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
@@ -36,15 +36,11 @@ function RouteComponent() {
     },
     {
       title: "First Air Date",
-      value: tvShow.first_air_date
-        ? formatDateAsLongMonth(tvShow.first_air_date)
-        : "N/A",
+      value: tvShow.first_air_date ? date(tvShow.first_air_date) : "N/A",
     },
     {
       title: "Last Air Date",
-      value: tvShow.last_air_date
-        ? formatDateAsLongMonth(tvShow.last_air_date)
-        : "N/A",
+      value: tvShow.last_air_date ? date(tvShow.last_air_date) : "N/A",
     },
     {
       title: "Seasons",

--- a/libs/utils/src/date.ts
+++ b/libs/utils/src/date.ts
@@ -1,15 +1,11 @@
-const yearOnlyFormatter = new Intl.DateTimeFormat("en-US", { year: "numeric" });
-
-export const formatDateAsYearOnly = (date: string) => {
-  return yearOnlyFormatter.format(new Date(date));
-};
-
-const longMonthFormatter = new Intl.DateTimeFormat("en-US", {
-  day: "numeric",
-  month: "long",
-  year: "numeric",
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
 });
 
-export const formatDateAsLongMonth = (date: string) => {
-  return longMonthFormatter.format(new Date(date));
+export const date = (date: string) => {
+  return dateFormatter.format(new Date(date));
+};
+
+export const year = (date: string) => {
+  return new Date(date).getFullYear();
 };

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,2 +1,2 @@
-export { formatDateAsLongMonth, formatDateAsYearOnly } from "./date";
+export { date, year } from "./date";
 export { random } from "./random";


### PR DESCRIPTION
🏁 Closes: #76, closes #79